### PR TITLE
Revise unconscious trigger

### DIFF
--- a/Prefabs/MP/Modes/GameMode_Base.et
+++ b/Prefabs/MP/Modes/GameMode_Base.et
@@ -2,6 +2,7 @@ SCR_BaseGameMode {
  ID "56B2B479C6B96951"
  components {
   SCR_GameModeHealthSettings "{5A22E11F9ACBB1DF}" {
+   m_fDOTScale 0.56
    m_bPermitUnconsciousness 1
   }
  }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ https://reforger.armaplatform.com/workshop/6FD4307E24115E90-ReviveSystemAlpha
 
 ### Mission Header Parameters
 
-- Time in seconds before an unconscious unit bleeds out (default: `300`): `"m_fUnconsciousBleedoutDuration"`
+- Bleeding rate multiplier (default: `0.56`): `"m_fBleedingRate"`
+- Health and blood level regeneration rate multiplier (default: `1.00`): `"m_fHealthAndBloodRegenerationRate"`
 
 ## Contributing
 

--- a/Scripts/Game/Components/Gadgets/modded/SCR_ConsumableBandage.c
+++ b/Scripts/Game/Components/Gadgets/modded/SCR_ConsumableBandage.c
@@ -19,10 +19,9 @@ modded class SCR_ConsumableBandage : SCR_ConsumableEffectHealthItems
 			return;
 		
 		// Unit gets revived if no bleeding wound is present
-		if (targetController.IsUnconscious() && !targetDamageMan.IsDamagedOverTime(EDamageType.BLEEDING))
+		if (targetDamageMan.IsUnconscious() && !targetDamageMan.IsDamagedOverTime(EDamageType.BLEEDING))
 		{
-			targetDamageMan.FullHeal();
-			targetController.SetUnconscious(false);
+			targetDamageMan.SetUnconscious(false);
 		};
 	};
 };

--- a/Scripts/Game/GameMode/Misc/modded/SCR_GameModeHealthSettings.c
+++ b/Scripts/Game/GameMode/Misc/modded/SCR_GameModeHealthSettings.c
@@ -1,15 +1,16 @@
 modded class SCR_GameModeHealthSettings : ScriptComponent
 {	
-	[Attribute(defvalue: "300", uiwidget: UIWidgets.EditBox, desc: "How long it takes in seconds for an unconscious unit to bleed out")]
-	protected float m_fUnconsciousBleedoutDuration;
-
-	float GetUnconsciousBleedoutDuration()
+	[Attribute("1", desc: "Scenario header setting will overwrite these values.")];
+	protected bool m_bAllowHeaderSettings;
+	
+	override void OnPostInit(IEntity owner)
 	{
 		SCR_MissionHeader header = SCR_MissionHeader.Cast(GetGame().GetMissionHeader());
 		
-		if (!header)
-			return m_fUnconsciousBleedoutDuration;
-		
-		return header.m_fUnconsciousBleedoutDuration;
+		if (m_bAllowHeaderSettings && header)
+		{
+			m_fDOTScale = header.m_fBleedingRate;
+			m_fRegenScale = header.m_fHealthAndBloodRegenerationRate;
+		};
 	};
 };

--- a/Scripts/Game/Mission/modded/SCR_MissionHeader.c
+++ b/Scripts/Game/Mission/modded/SCR_MissionHeader.c
@@ -1,5 +1,8 @@
 modded class SCR_MissionHeader : MissionHeader
 {
-	[Attribute(defvalue: "300", uiwidget: UIWidgets.EditBox, desc: "How long it takes in seconds for an unconscious unit to bleed out")]
-	float m_fUnconsciousBleedoutDuration;
+	[Attribute(defvalue: "0.56", uiwidget: UIWidgets.EditBox, desc: "A global bleeding rate multiplier. The higher the value, the faster entities will bleed to death.")]
+	float m_fBleedingRate;
+	
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.EditBox, desc: "A global multiplier affecting how fast entities will recover health and blood levels. The higher the value, the faster the regeneration.")]
+	float m_fHealthAndBloodRegenerationRate;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Move unconscious trigger from `OnDamageStateChanged` to `OnDamage`
- Negate all damage for 1 second when unit falls unconscious
- Resolves #18
- Lower default bleeding rate to `0.56`
- Make bleeding, blood and health regeneration rates configurable